### PR TITLE
Add model selection to OpenAI setup for enhanced customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitfy",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "main": "lib/index.js",
   "repository": "https://github.com/ribeirogab/commitfy.git",
   "author": "ribeirogab <ribeirogabx@gmail.com>",

--- a/src/interfaces/utils/env.utils.ts
+++ b/src/interfaces/utils/env.utils.ts
@@ -1,11 +1,15 @@
+import type { ChatModel } from 'openai/resources';
+
 import type { SetupContextEnum } from '../commands/setup';
 import type { ProviderEnum } from '../provider';
 
 export type Env = {
   PROVIDER?: ProviderEnum;
+  SETUP_CONTEXT: SetupContextEnum;
+
   OPENAI_API_KEY?: string;
   OPENAI_N_COMMITS?: number | string;
-  SETUP_CONTEXT: SetupContextEnum;
+  OPENAI_CHAT_MODEL?: ChatModel;
 
   CONFIG_COMMIT_LANGUAGE: string;
   CONFIG_MAX_COMMIT_CHARACTERS: string | number;

--- a/src/interfaces/utils/input.utils.ts
+++ b/src/interfaces/utils/input.utils.ts
@@ -29,5 +29,5 @@ export interface InputList extends DefaultInput {
 export type InputPromptDto = Input | InputList;
 
 export interface InputUtils {
-  prompt(input: InputPromptDto): Promise<string>;
+  prompt<T = string>(input: InputPromptDto): Promise<T>;
 }

--- a/src/providers/openai.provider.spec.ts
+++ b/src/providers/openai.provider.spec.ts
@@ -132,6 +132,7 @@ describe('OpenAIProvider', () => {
 
       vi.spyOn(inputUtils, 'prompt')
         .mockResolvedValueOnce('new-api-key')
+        .mockResolvedValueOnce('chat-model')
         .mockResolvedValueOnce('3');
 
       const loggerMessageSpy = vi.spyOn(appUtils.logger, 'message');
@@ -144,6 +145,7 @@ describe('OpenAIProvider', () => {
 
       expect(envUtils.update).toHaveBeenCalledWith({
         ...DEFAULT_ENV,
+        OPENAI_CHAT_MODEL: 'chat-model',
         OPENAI_API_KEY: 'new-api-key',
         OPENAI_N_COMMITS: 3,
         PROVIDER: ProviderEnum.OpenAI,

--- a/src/utils/input.utils.ts
+++ b/src/utils/input.utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@/interfaces';
 
 export class InputUtils implements InputUtilsInterface {
-  public async prompt(input: InputPromptDto) {
+  public async prompt<T = string>(input: InputPromptDto) {
     try {
       const promptDto = [{ name: 'data', ...input }];
 
@@ -24,7 +24,7 @@ export class InputUtils implements InputUtilsInterface {
         Object.assign(promptDto[0], { choices: choicesWithCustom });
       }
 
-      const { data } = await inquirer.prompt(promptDto as never);
+      const { data } = await inquirer.prompt<{ data: T }>(promptDto as never);
 
       return data;
     } catch (error) {


### PR DESCRIPTION
This pull request introduces a new feature to the OpenAI setup process, allowing users to select their preferred language model during configuration. Key changes include:

- Added support for `OPENAI_CHAT_MODEL` in environment variables to store the selected model.
- Implemented a user prompt to choose from predefined models such as `gpt-4`, `gpt-3.5-turbo`, and others.
- Updated `OpenAIProvider` to dynamically utilize the selected model in API requests, with a default fallback to `gpt-4o-mini`.
- Improved type safety by integrating `ChatModel` typing from OpenAI's resources.
- Enhanced tests to validate the new model selection functionality.
- Updated the package version to `0.3.0` to reflect the new feature.

This update provides users with greater flexibility and control over the language model, improving customization to better meet diverse requirements.